### PR TITLE
Implement MySQL/MariaDB Limit 65536

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -2,6 +2,7 @@
 
 namespace Staudenmeir\EloquentParamLimitFix;
 
+use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\SqlServerConnection;
 
@@ -19,6 +20,7 @@ class Builder extends \Illuminate\Database\Eloquent\Builder
     protected $parameterLimits = [
         SQLiteConnection::class => 900,
         SqlServerConnection::class => 2000,
+        MySqlConnection::class => 65536,
     ];
 
     /**


### PR DESCRIPTION
According to https://stackoverflow.com/a/24447922 there is a limit for MariaDB 10.5: 65536

I have received the following error message:

General error: 1390 Prepared statement contains too many placeholders

As discussed [here](https://github.com/laravel/framework/issues/31882)