### PR TITLE
Add limit for PostgreSQL

### DIFF
--- a/src/Traits/BuildsParamLimitFixQueries.php
+++ b/src/Traits/BuildsParamLimitFixQueries.php
@@ -20,9 +20,9 @@ trait BuildsParamLimitFixQueries
      */
     protected $parameterLimits = [
         MySqlConnection::class => 65000,
+        PostgresConnection::class => 65000,
         SQLiteConnection::class => 900,
         SqlServerConnection::class => 2000,
-        PostgresConnection::class => 65000,
     ];
 
     /**

--- a/src/Traits/BuildsParamLimitFixQueries.php
+++ b/src/Traits/BuildsParamLimitFixQueries.php
@@ -3,6 +3,7 @@
 namespace Staudenmeir\EloquentParamLimitFix\Traits;
 
 use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\SqlServerConnection;
 
@@ -21,6 +22,7 @@ trait BuildsParamLimitFixQueries
         MySqlConnection::class => 65000,
         SQLiteConnection::class => 900,
         SqlServerConnection::class => 2000,
+        PostgresConnection::class => 65000,
     ];
 
     /**


### PR DESCRIPTION
Hi,

As described in https://www.postgresql.org/docs/current/limits.html PostgreSQL has a 65535 limit.
I've copied the limit from MySQL to match this one.

Thanks!